### PR TITLE
Adds deno example using pgx

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,3 @@
+[build]
+# Postgres symbols won't be available until runtime
+rustflags = ["-C", "link-args=-Wl,-undefined,dynamic_lookup"]

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.DS_Store
+.idea/
+/target
+*.iml
+**/*.rs.bk
+Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "pldeno"
+version = "0.0.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[features]
+default = ["pg13"]
+pg10 = ["pgx/pg10", "pgx-tests/pg10" ]
+pg11 = ["pgx/pg11", "pgx-tests/pg11" ]
+pg12 = ["pgx/pg12", "pgx-tests/pg12" ]
+pg13 = ["pgx/pg13", "pgx-tests/pg13" ]
+pg14 = ["pgx/pg14", "pgx-tests/pg14" ]
+pg_test = []
+
+[dependencies]
+pgx = "0.4.3"
+deno_core = "0.130.0"
+tokio = { version = "1.17", features = ["full"] }
+serde_json = "1.0.79"
+serde_v8 = "0.41.0"
+
+[dev-dependencies]
+pgx-tests = "0.4.3"
+
+[profile.dev]
+panic = "unwind"
+lto = "thin"
+
+[profile.release]
+panic = "unwind"
+opt-level = 3
+lto = "fat"
+codegen-units = 1

--- a/pldeno.control
+++ b/pldeno.control
@@ -1,0 +1,5 @@
+comment = 'pldeno:  Created by pgx'
+default_version = '@CARGO_VERSION@'
+module_pathname = '$libdir/pldeno'
+relocatable = false
+superuser = false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,109 @@
+// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+//!  This example shows you how to define ops in Rust and then call them from
+//!  JavaScript.
+// https://github.com/denoland/deno/blob/main/core/examples/hello_world.rs
+// https://github.com/denoland/deno/blob/main/core/examples/http_bench_json_ops.rs
+
+use deno_core::v8;
+use deno_core::JsRuntime;
+use deno_core::RuntimeOptions;
+use pgx::*;
+
+pg_module_magic!();
+
+// https://github.com/denoland/deno/blob/main/core/examples/eval_js_value.rs
+fn eval(context: &mut JsRuntime, code: &str) -> Result<serde_json::Value, String> {
+    let res = context.execute_script("<anon>", code);
+    match res {
+        Ok(global) => {
+            let scope = &mut context.handle_scope();
+            let local = v8::Local::new(scope, global);
+            // Deserialize a `v8` object into a Rust type using `serde_v8`,
+            // in this case deserialize to a JSON `Value`.
+            let deserialized_value = serde_v8::from_v8::<serde_json::Value>(scope, local);
+
+            match deserialized_value {
+                Ok(value) => Ok(value),
+                Err(err) => Err(format!("Cannot deserialize value: {:?}", err)),
+            }
+        }
+        Err(err) => Err(format!("Evaling error: {:?}", err)),
+    }
+}
+
+#[pg_extern]
+fn pldeno_execute(code: &str) -> pgx::JsonB {
+    let mut runtime = JsRuntime::new(RuntimeOptions::default());
+
+    // Evaluate some code
+    let output: serde_json::Value = eval(&mut runtime, code).expect("Eval failed");
+
+    pgx::JsonB(output)
+}
+
+// #[pg_extern]
+// fn hello_pldeno() {
+// // fn hello_pldeno() ->&'static str {
+
+//     let mut js_runtime = create_js_runtime();
+//     let runtime = tokio::runtime::Builder::new_current_thread()
+//         .enable_all()
+//         .build()
+//         .unwrap();
+//     let future = async move {
+//         js_runtime
+//             .execute_script(
+//                 "<usage>",
+//                 r#"
+// // Print helper function, calling Deno.core.print()
+// function main() {
+//   return { "hello": "value" };
+// }
+// main();
+//                 "#,
+//             )
+//             .unwrap();
+//         js_runtime.run_event_loop(false).await
+//     };
+//     let res = runtime.block_on(future).unwrap();
+//     return res
+//     // return "hello_pldeno";
+
+//     //   runtime
+//     //     .execute_script(
+//     //       "<usage>",
+//     //       r#"
+//     // function print(value) {
+//     //   Deno.core.print(value.toString()+"\n");
+//     // }
+//     // // Print helper function, calling Deno.core.print()
+//     // const arr = [1, 2, 3];
+//     // print("The sum of");
+//     // "#,
+//     //     )
+//     //     .unwrap();
+//     // return "hello_pldeno";
+// }
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pg_schema]
+mod tests {
+    // use pgx::*;
+
+    // #[pg_test]
+    // fn test_hello_pldeno() {
+    //     assert_eq!("Hello, pldeno", crate::hello_pldeno());
+    // }
+}
+
+#[cfg(test)]
+pub mod pg_test {
+    pub fn setup(_options: Vec<&str>) {
+        // perform one-off initialization when the pg_test framework starts
+    }
+
+    pub fn postgresql_conf_options() -> Vec<&'static str> {
+        // return any postgresql.conf settings that are required for your tests
+        vec![]
+    }
+}


### PR DESCRIPTION
Adds a basic POC to see whether Deno can be using inside Postgres. 

### Why:

If we can get this running, then supabase devs get an isomorphic development language - running both on the edge and in the database. This is particularly useful for some of the ABAC ideas, which currently use plv8. This would be a replacement for plv8 and would give developers the benefit of a "write once, run anywhere" environment


### POC:

- We use pgx to scaffold an extension ✅ 
- initialise the Deno runtime inside the extension ✅ 
- execute a typescript statement within the Deno runtime ✅ 

### Next steps:

Currently this runs as an extension. We need to convert this over to a language extension. There is some prior art [here](https://github.com/tcdi/plrust/blob/627a2459eaeb97097b4639e5e71e4f8d057e412c/src/lib.rs#L79), where plrust is implemented using pgx.


### Usage:

```
cargo build
cargo pgx init # one time
cargo pgx run pg13
```

see full history here: https://github.com/supabase/pldeno-test

### alternative approaches:

- Don't use Deno. We could still use plv8, but we might want to add a build pipeline to transpile code into plv8 native code. Here is a discussion with one of our customers on supporting different langauges: https://supabase.slack.com/archives/C02A1CHMWGZ/p1650482428265519

